### PR TITLE
[WIP] Export NewClusterClientAO

### DIFF
--- a/libcarina.go
+++ b/libcarina.go
@@ -120,7 +120,8 @@ func (n *number) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func newClusterClient(endpoint string, ao gophercloud.AuthOptions) (*ClusterClient, error) {
+// NewClusterClientAO straight from gophercloud.AuthOptions
+func NewClusterClientAO(endpoint string, ao gophercloud.AuthOptions) (*ClusterClient, error) {
 	provider, err := rackspace.AuthenticatedClient(ao)
 	if err != nil {
 		return nil, err
@@ -142,7 +143,7 @@ func NewClusterClient(endpoint, username, apikey string) (*ClusterClient, error)
 		IdentityEndpoint: rackspace.RackspaceUSIdentity,
 	}
 
-	return newClusterClient(endpoint, ao)
+	return NewClusterClientAO(endpoint, ao)
 }
 
 // NewRequest handles a request using auth used by Carina


### PR DESCRIPTION
Putting this out, was useful in mocking up a branch for `rack`.

Not intended to be merged, requires that `AuthOptions.Username` is set.
