### PR TITLE
Use nodes as an integer directly.

### DIFF
--- a/libcarina.go
+++ b/libcarina.go
@@ -411,8 +411,10 @@ func fetchZip(zipurl string) (*zip.Reader, error) {
 
 // Grow increases a cluster by the provided number of nodes
 func (c *ClusterClient) Grow(clusterName string, nodes int) (*Cluster, error) {
-	incr := make(map[string]json.Number)
-	incr["nodes"] = json.Number(nodes)
+	incr := map[string]int{
+		"nodes": nodes,
+	}
+
 	growthRequest, err := json.Marshal(incr)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
`json.Number` was not working properly on serialization, coming up with

``` json
{"nodes":}
```

This fixes that and I'm done scratching my head.
