### PR TITLE
If the body is nil, return an error.

### DIFF
--- a/libcarina.go
+++ b/libcarina.go
@@ -164,6 +164,9 @@ func (c *ClusterClient) NewRequest(method string, uri string, body io.Reader) (*
 	}
 
 	if resp.StatusCode >= 400 {
+		if resp.Body == nil {
+			return nil, errors.New(resp.Status)
+		}
 		b, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			return nil, errors.New(resp.Status)


### PR DESCRIPTION
Ensure sanity from upstream.
