### PR TITLE
Fix test for if a string is a cluster id

### DIFF
--- a/libcarina.go
+++ b/libcarina.go
@@ -198,7 +198,7 @@ func clusterFromResponse(resp *http.Response, err error) (*Cluster, error) {
 }
 
 func isClusterID(token string) bool {
-	r := regexp.MustCompile("^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[8|9|aA|bB][a-f0-9]{3}-[a-f0-9]{12}$")
+	r := regexp.MustCompile("^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$")
 	return r.MatchString(token)
 }
 


### PR DESCRIPTION
I don't know what I was drinking when I crufted that up, it filters out valid ids, causing an extra API call to `/clusters`. THIS time I'm _sure_ it will work... ;-)

cc @thomasem 