### PR TITLE
Fix cert names

### DIFF
--- a/credentials.go
+++ b/credentials.go
@@ -59,12 +59,12 @@ func (creds *CredentialsBundle) GetCA() []byte {
 
 // GetCert returns the contents of cert.pem
 func (creds *CredentialsBundle) GetCert() []byte {
-	return creds.Files["user.pem"]
+	return creds.Files["cert.pem"]
 }
 
 // GetKey returns the contents of key.pem
 func (creds *CredentialsBundle) GetKey() []byte {
-	return creds.Files["user-key.pem"]
+	return creds.Files["key.pem"]
 }
 
 // Verify validates that we can connect to the Docker host specified in the credentials bundle


### PR DESCRIPTION
Previously k8's and swarm used different cert names, and we were incorrectly only using the filenames for the k8's certs. Now they are both using the same filenames again.