### PR TITLE
Standardize UserAgent header

### DIFF
--- a/libcarina.go
+++ b/libcarina.go
@@ -17,8 +17,8 @@ import (
 	"github.com/rackspace/gophercloud/rackspace"
 )
 
-// UserAgentPrefix is the default user agent string, consumers should append their application version to CarinaClient.UserAgent
-const UserAgentPrefix = "getcarina/libcarina"
+// UserAgentPrefix is the default user agent string, consumers should append their application version to `CarinaClient.UserAgent`.
+const UserAgentPrefix = "libcarina/" + LibVersion
 
 // CarinaClient accesses Carina directly
 type CarinaClient struct {

--- a/metadata.go
+++ b/metadata.go
@@ -3,6 +3,9 @@ package libcarina
 // SupportedAPIVersion is the version of the API against which this library was developed
 const SupportedAPIVersion = "1.0"
 
+// LibVersion is the version of this library, and should be keep synchronized with the git tag
+const LibVersion = "2.0.0"
+
 // CarinaEndpointType is the endpoint type in the service catalog
 const CarinaEndpointType = "rax:container"
 


### PR DESCRIPTION
`libcarina/VERSION` where version is the version of the library. The library version should be kept in sync with the git tag.

First step for https://github.com/getcarina/carina/issues/129